### PR TITLE
Explicit full path from download to install

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -76,7 +76,7 @@ Note : if you restart your iptables, the nocloud rules will be dropped. no-cloud
 
 Only thing to do is :
 
- git clone git@github.com:n0vember/nocloud.git
+ git clone https://gitlab.com/n0vember/nocloud
  cd nocloud
  sudo make
 

--- a/README.adoc
+++ b/README.adoc
@@ -76,6 +76,8 @@ Note : if you restart your iptables, the nocloud rules will be dropped. no-cloud
 
 Only thing to do is :
 
+ git clone git@github.com:n0vember/nocloud.git
+ cd nocloud
  sudo make
 
 == Configuration


### PR DESCRIPTION
Not sure if it is a great idea but I though that, maybe, it was cool to explicit all steps to install nocloud, including git clone.